### PR TITLE
fix: mask float traps

### DIFF
--- a/src/quilc/compile.lisp
+++ b/src/quilc/compile.lisp
@@ -70,7 +70,7 @@
 
 (defun compile-protoquil (parsed-program chip-specification metadata-ptr)
   (multiple-value-bind (compiled-program metadata)
-      (process-program parsed-program chip-specification :protoquil t)
+      (magicl:with-blapack (process-program parsed-program chip-specification :protoquil t))
     (unless (null-pointer-p metadata-ptr)
       (let ((handle (sbcl-librarian::make-handle metadata)))
         (setf (sb-alien:deref metadata-ptr)


### PR DESCRIPTION
Sometimes the LAPACK library for macOS will hit a division-by-zero. Mask those interrupts so they can be handled in Lisp.